### PR TITLE
Initialize Node chat backend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,15 @@
+# MongoDB connection URI
+DB_URI=mongodb://localhost:27017/chat
+
+# Redis connection URL
+REDIS_URL=redis://localhost:6379
+
+# JWT secrets
+JWT_SECRET=your_jwt_secret
+JWT_REFRESH_SECRET=your_refresh_secret
+
+# Application port
+PORT=3000
+
+# Allowed CORS origins (comma separated)
+CORS_ORIGIN=http://localhost:3000

--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# Chat Backend
+
+This project provides a Node.js backend for a real-time chat application using Express, Socket.IO and MongoDB.
+
+## Setup
+
+1. Copy `.env.example` to `.env` and fill in the values.
+2. Install dependencies with `npm install`.
+3. Run in development mode:
+
+```bash
+npm run dev
+```

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "mongoose": "^8.15.1",
     "redis": "^5.5.6",
     "socket.io": "^4.8.1",
+    "@socket.io/redis-adapter": "^8.2.0",
     "winston": "^3.17.0"
   }
 }

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -1,0 +1,10 @@
+import { Router } from 'express';
+import { signup, login, refresh } from '../controllers/authController';
+
+const router = Router();
+
+router.post('/signup', signup);
+router.post('/login', login);
+router.post('/refresh', refresh);
+
+export default router;

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,0 +1,10 @@
+import { Router } from 'express';
+import auth from './auth';
+import messages from './messages';
+
+const router = Router();
+
+router.use('/auth', auth);
+router.use('/messages', messages);
+
+export default router;

--- a/src/api/messages.ts
+++ b/src/api/messages.ts
@@ -1,0 +1,10 @@
+import { Router } from 'express';
+import { createMessage, getMessages } from '../controllers/messageController';
+import { verifyToken } from '../middlewares/auth';
+
+const router = Router();
+
+router.post('/', verifyToken, createMessage);
+router.get('/', verifyToken, getMessages);
+
+export default router;

--- a/src/config/db.ts
+++ b/src/config/db.ts
@@ -1,0 +1,7 @@
+import mongoose from 'mongoose';
+
+export const connectDb = async () => {
+  const uri = process.env.DB_URI as string;
+  if (!uri) throw new Error('DB_URI is not defined');
+  await mongoose.connect(uri);
+};

--- a/src/config/redis.ts
+++ b/src/config/redis.ts
@@ -1,0 +1,11 @@
+import { createClient } from 'redis';
+
+const url = process.env.REDIS_URL as string;
+export const redisClient = createClient({ url });
+
+export const connectRedis = async () => {
+  if (!url) throw new Error('REDIS_URL is not defined');
+  if (!redisClient.isOpen) {
+    await redisClient.connect();
+  }
+};

--- a/src/config/socket.ts
+++ b/src/config/socket.ts
@@ -1,0 +1,19 @@
+import { Server } from 'socket.io';
+import { createAdapter } from '@socket.io/redis-adapter';
+import { createServer } from 'http';
+import { redisClient } from './redis';
+
+export const initSocket = (app: any) => {
+  const httpServer = createServer(app);
+  const io = new Server(httpServer, {
+    cors: {
+      origin: process.env.CORS_ORIGIN?.split(',') || '*',
+    },
+  });
+
+  const pubClient = redisClient.duplicate();
+  const subClient = redisClient.duplicate();
+  io.adapter(createAdapter(pubClient, subClient));
+
+  return { io, httpServer };
+};

--- a/src/controllers/authController.ts
+++ b/src/controllers/authController.ts
@@ -1,0 +1,43 @@
+import { Request, Response } from 'express';
+import jwt from 'jsonwebtoken';
+import { User } from '../models/User';
+
+const generateToken = (userId: string) =>
+  jwt.sign({ userId }, process.env.JWT_SECRET as string, { expiresIn: '15m' });
+
+const generateRefreshToken = (userId: string) =>
+  jwt.sign({ userId }, process.env.JWT_REFRESH_SECRET as string, { expiresIn: '7d' });
+
+export const signup = async (req: Request, res: Response) => {
+  try {
+    const { username, email, password } = req.body;
+    const user = await User.create({ username, email, password });
+    const token = generateToken(user.id);
+    const refreshToken = generateRefreshToken(user.id);
+    res.json({ token, refreshToken });
+  } catch (err) {
+    res.status(400).json({ message: 'Signup failed', error: err });
+  }
+};
+
+export const login = async (req: Request, res: Response) => {
+  const { email, password } = req.body;
+  const user = await User.findOne({ email });
+  if (!user || !(await user.comparePassword(password))) {
+    return res.status(401).json({ message: 'Invalid credentials' });
+  }
+  const token = generateToken(user.id);
+  const refreshToken = generateRefreshToken(user.id);
+  res.json({ token, refreshToken });
+};
+
+export const refresh = async (req: Request, res: Response) => {
+  const { refreshToken } = req.body;
+  try {
+    const payload = jwt.verify(refreshToken, process.env.JWT_REFRESH_SECRET as string) as any;
+    const token = generateToken(payload.userId);
+    res.json({ token });
+  } catch {
+    res.status(401).json({ message: 'Invalid refresh token' });
+  }
+};

--- a/src/controllers/messageController.ts
+++ b/src/controllers/messageController.ts
@@ -1,0 +1,17 @@
+import { Request, Response } from 'express';
+import { Message } from '../models/Message';
+
+export const createMessage = async (req: Request, res: Response) => {
+  const { recipient, content } = req.body;
+  const sender = (req as any).user.userId;
+  const message = await Message.create({ sender, recipient, content });
+  res.status(201).json(message);
+};
+
+export const getMessages = async (req: Request, res: Response) => {
+  const userId = (req as any).user.userId;
+  const messages = await Message.find({
+    $or: [{ sender: userId }, { recipient: userId }],
+  }).sort({ createdAt: -1 });
+  res.json(messages);
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,38 @@
+import express from 'express';
+import cors from 'cors';
+import helmet from 'helmet';
+import rateLimit from 'express-rate-limit';
+import dotenv from 'dotenv';
+import api from './api';
+import { connectDb } from './config/db';
+import { connectRedis } from './config/redis';
+import { initSocket } from './config/socket';
+import { errorHandler } from './middlewares/errorHandler';
+import { registerSocketEvents } from './services/socketService';
+
+dotenv.config();
+
+const app = express();
+app.use(express.json());
+app.use(cors({ origin: process.env.CORS_ORIGIN?.split(',') }));
+app.use(helmet());
+app.use(rateLimit({ windowMs: 60 * 1000, max: 100 }));
+
+app.use('/api', api);
+app.use(errorHandler);
+
+const start = async () => {
+  await connectDb();
+  await connectRedis();
+
+  const { io, httpServer } = initSocket(app);
+  registerSocketEvents(io);
+
+  const port = process.env.PORT || 3000;
+  httpServer.listen(port, () => console.log(`Server running on port ${port}`));
+};
+
+start().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/middlewares/auth.ts
+++ b/src/middlewares/auth.ts
@@ -1,0 +1,20 @@
+import { Request, Response, NextFunction } from 'express';
+import jwt from 'jsonwebtoken';
+
+export interface AuthRequest extends Request {
+  user?: any;
+}
+
+export const verifyToken = (req: AuthRequest, res: Response, next: NextFunction) => {
+  const header = req.headers.authorization;
+  if (!header) return res.status(401).json({ message: 'Unauthorized' });
+
+  const token = header.split(' ')[1];
+  try {
+    const payload = jwt.verify(token, process.env.JWT_SECRET as string);
+    req.user = payload;
+    next();
+  } catch {
+    return res.status(401).json({ message: 'Invalid token' });
+  }
+};

--- a/src/middlewares/errorHandler.ts
+++ b/src/middlewares/errorHandler.ts
@@ -1,0 +1,12 @@
+import { Request, Response, NextFunction } from 'express';
+import { logger } from '../utils/logger';
+
+export const errorHandler = (
+  err: any,
+  _req: Request,
+  res: Response,
+  _next: NextFunction
+) => {
+  logger.error(err);
+  res.status(500).json({ message: 'Internal Server Error' });
+};

--- a/src/models/Message.ts
+++ b/src/models/Message.ts
@@ -1,0 +1,19 @@
+import { Schema, model, Document, Types } from 'mongoose';
+
+export interface IMessage extends Document {
+  sender: Types.ObjectId;
+  recipient: Types.ObjectId;
+  content: string;
+  createdAt: Date;
+  read: boolean;
+}
+
+const messageSchema = new Schema<IMessage>({
+  sender: { type: Schema.Types.ObjectId, ref: 'User', index: true },
+  recipient: { type: Schema.Types.ObjectId, ref: 'User', index: true },
+  content: { type: String, required: true },
+  createdAt: { type: Date, default: Date.now, index: true },
+  read: { type: Boolean, default: false },
+});
+
+export const Message = model<IMessage>('Message', messageSchema);

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -1,0 +1,28 @@
+import { Schema, model, Document } from 'mongoose';
+import bcrypt from 'bcrypt';
+
+export interface IUser extends Document {
+  username: string;
+  email: string;
+  password: string;
+  comparePassword: (candidate: string) => Promise<boolean>;
+}
+
+const userSchema = new Schema<IUser>({
+  username: { type: String, required: true, unique: true },
+  email: { type: String, required: true, unique: true },
+  password: { type: String, required: true },
+});
+
+userSchema.pre('save', async function (next) {
+  if (!this.isModified('password')) return next();
+  const salt = await bcrypt.genSalt(10);
+  this.password = await bcrypt.hash(this.password, salt);
+  next();
+});
+
+userSchema.methods.comparePassword = function (candidate: string) {
+  return bcrypt.compare(candidate, this.password);
+};
+
+export const User = model<IUser>('User', userSchema);

--- a/src/services/socketService.ts
+++ b/src/services/socketService.ts
@@ -1,0 +1,16 @@
+import { Server } from 'socket.io';
+import { Message } from '../models/Message';
+
+export const registerSocketEvents = (io: Server) => {
+  io.on('connection', (socket) => {
+    socket.on('join', (room: string) => {
+      socket.join(room);
+    });
+
+    socket.on('message', async ({ room, content }) => {
+      const userId = (socket as any).userId;
+      const message = await Message.create({ sender: userId, recipient: room, content });
+      io.to(room).emit('message', message);
+    });
+  });
+};

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,0 +1,6 @@
+import winston from 'winston';
+
+export const logger = winston.createLogger({
+  level: 'info',
+  transports: [new winston.transports.Console()],
+});


### PR DESCRIPTION
## Summary
- scaffold chat backend folders and TypeScript entry
- set up MongoDB and Redis connectors
- implement auth and message controllers
- wire socket.io server with Redis adapter
- add JWT middleware and error handler
- document environment variables in `.env.example`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6847e87f52c48331b5ed1afa47fc336c